### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]

--- a/README.md
+++ b/README.md
@@ -319,9 +319,9 @@ public void UpdateEmail(string email)
 # Summary
 |||
 |:---|:---|
-| Generated on: | 09/04/2025 - 20:34:01 |
-| Coverage date: | 09/03/2025 - 19:56:53 - 09/04/2025 - 20:33:59 |
-| Parser: | MultiReport (11x Cobertura) |
+| Generated on: | 09/05/2025 - 10:22:40 |
+| Coverage date: | 09/03/2025 - 19:56:53 - 09/05/2025 - 10:22:37 |
+| Parser: | MultiReport (12x Cobertura) |
 | Assemblies: | 1 |
 | Classes: | 15 |
 | Files: | 50 |


### PR DESCRIPTION
Potential fix for [https://github.com/selcukgural/SGuard/security/code-scanning/2](https://github.com/selcukgural/SGuard/security/code-scanning/2)

To fix this issue, explicitly set a minimal `permissions` block for the workflow. Unless any steps in the workflow need to create or modify contents or interact with issues or pull requests, the recommended minimum is `contents: read`, granting only read access to repository contents. This block should be added at the top of the workflow YAML file, after the `name:` but before (or right after) the `on:` block. Alternatively, it could be set at the job level, but the recommended way is to set it globally for the entire workflow unless different jobs need different permissions.

No additional imports or methods are needed; it's a single YAML addition. The edit should be made in `.github/workflows/ci.yml` before the `jobs:` block starts (ideally immediately after the `name: CI`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
